### PR TITLE
Adds tags for Schema.org 

### DIFF
--- a/islandora_social_metatags.module
+++ b/islandora_social_metatags.module
@@ -246,27 +246,6 @@ function islandora_social_metatags_islandora_view_object() {
         'property' => 'og:site_name',
         'content' => $site_name
       )
-    ),
-    'Schema.org Title' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'itemprop' => 'name',
-        'content' => $title
-      )
-    ),
-    'Schema.org Image' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'itemprop' => 'image',
-        'content' => $image
-      )
-    ),
-    'Schema.org Description' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'itemprop' => 'description',
-        'content' => $abstract
-      )
     )
   );
 

--- a/islandora_social_metatags.module
+++ b/islandora_social_metatags.module
@@ -162,6 +162,20 @@ function islandora_social_metatags_islandora_view_object() {
     drupal_add_html_head($val, $key);
   }
 
+  $tags = array(
+    'Schema.org Title' => array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        'itemprop' => 'name',
+        'content' => $title
+      )
+    )
+  );
+
+  foreach ($tags as $key => $val) {
+    drupal_add_html_head($val, $key);
+  }
+
 
   $tags = array(
     'Twitter image' => array(
@@ -191,6 +205,19 @@ function islandora_social_metatags_islandora_view_object() {
     drupal_add_html_head($val, $key);
   }
 
+  $tags = array(
+    'Schema.org Image' => array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        'itemprop' => 'image',
+        'content' => $image
+      )
+    )
+  );
+
+  foreach ($tags as $key => $val) {
+    drupal_add_html_head($val, $key);
+  }
 
   $tags = array(
     'Twitter site user' => array(
@@ -225,6 +252,20 @@ function islandora_social_metatags_islandora_view_object() {
       '#tag' => 'meta',
       '#attributes' => array(
         'property' => 'og:description',
+        'content' => $abstract
+      )
+    )
+  );
+
+  foreach ($tags as $key => $val) {
+    drupal_add_html_head($val, $key);
+  }
+
+  $tags = array(
+    'Schema.org Description' => array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        'itemprop' => 'description',
         'content' => $abstract
       )
     )

--- a/islandora_social_metatags.module
+++ b/islandora_social_metatags.module
@@ -69,24 +69,74 @@ function islandora_social_metatags_islandora_view_object() {
 
   $pid = $object->id;
 
-  // Get Image path. TO DO: Error handling if no image exists.
-  if (in_array('ir:citationCModel', $object->models)) {
-        $image_datastream = variable_get('islandora_social_metatags_citation_datastream', 'PREVIEW');
-  }
-  elseif (in_array('ir:thesisCModel', $object->models)) {
-    $image_datastream = variable_get('islandora_social_metatags_thesis_datastream', 'PREVIEW');
+  // Get Image path and item type. Item type required for schema.org tags.
+  if (in_array('ir:citationCModel', $object->models) || in_array('ir:thesisCModel', $object->models)) {
+    $image_datastream = variable_get('islandora_social_metatags_citation_datastream', 'PREVIEW');
+    $itemtype = "Article";
   }
   elseif (in_array('islandora:sp_large_image_cmodel', $object->models)) {
-   $image_datastream = variable_get('islandora_social_metatags_largeimage_datastream', 'JPG');
+    $image_datastream = variable_get('islandora_social_metatags_largeimage_datastream', 'JPG');
+    $itemtype = "ImageObject";
   }
   elseif (in_array('islandora:sp_basic_image', $object->models)) {
-   $image_datastream = variable_get('islandora_social_metatags_basicimage_datastream', 'MEDIUM_SIZE');
+    $image_datastream = variable_get('islandora_social_metatags_basicimage_datastream', 'MEDIUM_SIZE');
+    $itemtype = "ImageObject";
   }
   elseif (in_array('islandora:sp_videoCModel', $object->models)) {
-   $image_datastream = variable_get('islandora_social_metatags_video_datastream', 'TN');
+    $image_datastream = variable_get('islandora_social_metatags_video_datastream', 'TN');
+    $itemtype = "VideoObject";
+  }
+  elseif (in_array('islandora:personCModel', $object->models)) {
+    $image_datastream = "TN";
+    $itemtype = "Person";
+  }
+  elseif (in_array('islandora:sp_pdf', $object->models) || in_array('islandora:sp_document', $object->models)) {
+    $image_datastream = "PREVIEW";
+    $itemtype = "DigitalDocument";
+  }
+  elseif (in_array('islandora:collectionCModel', $object->models)) {
+    $image_datastream = "TN";
+    $itemtype = "CollectionPage";
+  }
+  elseif (in_array('islandora:sp-audioCModel', $object->models)) {
+    $image_datastream = "TN";
+    $itemtype = "AudioObject";
+  }
+  elseif (in_array('islandora:bookCModel', $object->models) || in_array ('islandora:pageCModel', $object->models)) {
+    $image_datastream = "TN";
+    $itemtype = "Book";
+  }
+  elseif (in_array('islandora:newspaperCModel', $object->models) || in_array('islandora:newspaperIssueCModel', $object->models)) {
+    $image_datastream = "TN";
+    $itemtype = "NewsArticle";
+  }
+  elseif (in_array('islandora:newspaperPageCModel', $object->models)) {
+    $image_datastream = "JPG";
+    $itemtype = "NewsArticle";
+  }
+  elseif (in_array('islandora:eventCModel', $object->models)) {
+    $image_datastream = "TN";
+    $itemtype = "Event";
+  }
+  elseif (in_array('islandora:placeCModel', $object->models)) {
+    $image_datastream = "TN";
+    $itemtype = "Place";
+  }
+  elseif (in_array('islandora:organizationCModel', $object->models)) {
+    $image_datastream = "TN";
+    $itemtype = "Organization";
+  }
+  elseif (in_array('islandora:sp_disk_image', $object->models)) {
+    $image_datastream = "TN";
+    $itemtype = "DataCatalog";
+  }
+  elseif (in_array('islandora:sp_web_archive', $object->models)) {
+    $image_datastream = "JPG";
+    $itemtype = "WebSite";
   }
   else {
     $image_datastream = "TN";
+    $itemtype = "Article";
   }
 
   global $base_url;
@@ -223,5 +273,12 @@ function islandora_social_metatags_islandora_view_object() {
   foreach ($tags as $key => $val) {
     drupal_add_html_head($val, $key);
   }
-}
 
+// Add the schema.org meta tags separately, as they require their own div.
+  print(
+    '<div itemscope itemtype = "http://schema.org/' . $itemtype . '">
+    <meta itemprop="name" content="' . $title . '">
+    <meta itemprop="description" content="' . $abstract . '">
+    <meta itemprop="image" content="' . $image . '"></div>'
+  );
+}

--- a/islandora_social_metatags.module
+++ b/islandora_social_metatags.module
@@ -141,13 +141,6 @@ function islandora_social_metatags_islandora_view_object() {
         'content' => $title
       )
     ),
-    'Schema.org Title' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'itemprop' => 'name',
-        'content' => $title
-      )
-    ),
     'Twitter image' => array(
       '#tag' => 'meta',
       '#attributes' => array(
@@ -159,13 +152,6 @@ function islandora_social_metatags_islandora_view_object() {
       '#tag' => 'meta',
       '#attributes' => array(
         'property' => 'og:image',
-        'content' => $image
-      )
-    ),
-    'Schema.org Image' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'itemprop' => 'image',
         'content' => $image
       )
     ),
@@ -190,13 +176,6 @@ function islandora_social_metatags_islandora_view_object() {
         'content' => $abstract
       )
     ),
-    'Schema.org Description' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'itemprop' => 'description',
-        'content' => $abstract
-      )
-    ),
     'Object type' => array(
       '#tag' => 'meta',
       '#attributes' => array(
@@ -217,11 +196,32 @@ function islandora_social_metatags_islandora_view_object() {
         'property' => 'og:site_name',
         'content' => $site_name
       )
+    ),
+    'Schema.org Title' => array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        'itemprop' => 'name',
+        'content' => $title
+      )
+    ),
+    'Schema.org Image' => array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        'itemprop' => 'image',
+        'content' => $image
+      )
+    ),
+    'Schema.org Description' => array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        'itemprop' => 'description',
+        'content' => $abstract
+      )
     )
   );
 
   foreach ($tags as $key => $val) {
     drupal_add_html_head($val, $key);
   }
-
 }
+

--- a/islandora_social_metatags.module
+++ b/islandora_social_metatags.module
@@ -118,7 +118,7 @@ function islandora_social_metatags_islandora_view_object() {
 /*
 * Implements drupal_add_html_head() to inject the meta tags
 */
-
+  $site_name = variable_get('site_name', 'Islandora');
   $tags = array(
     'Twitter card' => array(
       '#tag' => 'meta',
@@ -126,186 +126,91 @@ function islandora_social_metatags_islandora_view_object() {
         'name' => 'twitter:card',
         'content' => $card_type
       )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-  $tags = array(
+    ),
     'Twitter Title' => array(
       '#tag' => 'meta',
       '#attributes' => array(
         'name' => 'twitter:title',
         'content' => $title
       )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-
-  $tags = array(
+    ),
     'Facebook Title' => array(
       '#tag' => 'meta',
       '#attributes' => array(
         'property' => 'og:title',
         'content' => $title
       )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-  $tags = array(
+    ),
     'Schema.org Title' => array(
       '#tag' => 'meta',
       '#attributes' => array(
         'itemprop' => 'name',
         'content' => $title
       )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-
-  $tags = array(
+    ),
     'Twitter image' => array(
       '#tag' => 'meta',
       '#attributes' => array(
         'name' => 'twitter:image',
         'content' => $image
       )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-  $tags = array(
+    ),
     'Facebook image' => array(
       '#tag' => 'meta',
       '#attributes' => array(
         'property' => 'og:image',
         'content' => $image
       )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-  $tags = array(
+    ),
     'Schema.org Image' => array(
       '#tag' => 'meta',
       '#attributes' => array(
         'itemprop' => 'image',
         'content' => $image
       )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-  $tags = array(
+    ),
     'Twitter site user' => array(
       '#tag' => 'meta',
       '#attributes' => array(
         'name' => 'twitter:site',
         'content' => $twitter_user
       )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-  $tags = array(
+    ),
     'Twitter description' => array(
       '#tag' => 'meta',
       '#attributes' => array(
         'name' => 'twitter:description',
         'content' => $abstract 
       )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-  $tags = array(
+    ),
     'Facebook description' => array(
       '#tag' => 'meta',
       '#attributes' => array(
         'property' => 'og:description',
         'content' => $abstract
       )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-  $tags = array(
+    ),
     'Schema.org Description' => array(
       '#tag' => 'meta',
       '#attributes' => array(
         'itemprop' => 'description',
         'content' => $abstract
       )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-  $tags = array(
-    'Facebook URL' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'property' => 'og:url',
-        'content' => $og_url
-      )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-  $tags = array(
+    ),
     'Object type' => array(
       '#tag' => 'meta',
       '#attributes' => array(
         'property' => 'og:type',
         'content' => 'article'
       )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-  $site_name = variable_get('site_name', 'Islandora');
-
-  $tags = array(
+    ),
+    'Facebook URL' => array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        'property' => 'og:url',
+        'content' => $og_url
+      )
+    ),
     'Facebook site name' => array(
       '#tag' => 'meta',
       '#attributes' => array(


### PR DESCRIPTION
Adds schema.org tags, which are used by multiple applications including Google+ and Pinterest. Also makes the code more elegant by grouping the original tags and using a single foreach loop.

Schema.org tags require slightly special treatment since their meta tags must be nested within a div containing the itemscope and itemtype attributes, so they are printed separately from the other meta tags.

If anyone has a more elegant solution to this, I would welcome a PR to the schema_org branch before merge.