### PR TITLE
Compound object support - 2nd try

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -10,14 +10,14 @@ function islandora_social_metatags_admin_form($form, $form_settings) {
     '#description' => t('MODS XPath for retrieving the title.'),
     '#default_value' => variable_get('islandora_social_metatags_title_xpath', '/mods:mods/mods:titleInfo/mods:title'),
   );
-  
+
   $form['islandora_social_metatags_abstract_xpath'] = array(
     '#type' => 'textfield',
     '#title' => t('Abstract XPath'),
     '#description' => t('MODS XPath for the Description field. Defaults to mods:abstract.'),
     '#default_value' => variable_get('islandora_social_metatags_abstract_xpath', '/mods:mods/mods:abstract'),
   );
-  
+
   $form['islandora_social_metatags_twitter_user'] = array(
     '#type' => 'textfield',
     '#title' => t('Site Twitter user'),
@@ -66,5 +66,40 @@ function islandora_social_metatags_admin_form($form, $form_settings) {
     '#description' => t('If the above Image datastreams do not exist for a given object, use a basic default. Use a relative path.'),
     '#default_value' => variable_get('islandora_social_metatags_noimage', '/sites/all/modules/islandora/images/folder.png'),
   );
+  $form['islandora_social_metatags_compound_title'] = array(
+    '#type' => 'select',
+    '#title' => t('Compound Object Title Preference'),
+    '#description' => t('Do you prefer the child title, parent title, or both, concatenated?.'),
+    '#options' => array(
+      'child' => t('Child'),
+      'parent' => t('Parent'),
+      'concatenate' => t('Concatenated'),
+    ),
+    '#default_value' => variable_get('islandora_social_metatags_compound_title', 'concatenate'),
+  );
+  $form['islandora_social_metatags_compound_title_delimiter'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Compound Object Title Concatenation Delimiter'),
+    '#description' => t('If displaying the parent and child title, what characters should delimit them? <em>(No quotes, html tags or special characters permitted.)</em>'),
+    '#default_value' => variable_get('islandora_social_metatags_compound_title_delimiter', ': '),
+  );
+  $form['islandora_social_metatags_compound_abstract'] = array(
+    '#type' => 'select',
+    '#title' => t('Compound Object Abstract Preference'),
+    '#description' => t('Do you prefer the child\'s abstract, parent\'s abstract, or both?.'),
+    '#options' => array(
+      'child' => t('Child'),
+      'parent' => t('Parent'),
+      'concatenate' => t('Both'),
+    ),
+    '#default_value' => variable_get('islandora_social_metatags_compound_abstract', 'concatenate'),
+  );
+  $form['islandora_social_metatags_compound_abstract_delimiter'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Compound Object Title Concatenation Delimiter'),
+    '#description' => t('If displaying the parent and child abstract, what characters should delimit them? <em>(No quotes, html tags or special characters permitted.)</em>'),
+    '#default_value' => variable_get('islandora_social_metatags_compound_abstract_delimiter', ' :: '),
+  );
+
   return system_settings_form($form);
 }

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -69,7 +69,7 @@ function islandora_social_metatags_admin_form($form, $form_settings) {
   $form['islandora_social_metatags_compound_title'] = array(
     '#type' => 'select',
     '#title' => t('Compound Object Title Preference'),
-    '#description' => t('Do you prefer the child title, parent title, or both, concatenated?.'),
+    '#description' => t('On all child objects, use either the Parent\'s title, the Child\'s title, or concatenate both. If choosing Child, the first child object\'s title will be used when viewing the parent object.'),
     '#options' => array(
       'child' => t('Child'),
       'parent' => t('Parent'),
@@ -86,7 +86,7 @@ function islandora_social_metatags_admin_form($form, $form_settings) {
   $form['islandora_social_metatags_compound_abstract'] = array(
     '#type' => 'select',
     '#title' => t('Compound Object Abstract Preference'),
-    '#description' => t('Do you prefer the child\'s abstract, parent\'s abstract, or both?.'),
+    '#description' => t('On all child objects, use either the Parent\'s abstract, the Child\'s abstract, or concatenate both. If choosing Child, the first child object\'s abstract will be used when viewing the parent object.'),
     '#options' => array(
       'child' => t('Child'),
       'parent' => t('Parent'),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -80,7 +80,7 @@ function islandora_social_metatags_admin_form($form, $form_settings) {
   $form['islandora_social_metatags_compound_title_delimiter'] = array(
     '#type' => 'textfield',
     '#title' => t('Compound Object Title Concatenation Delimiter'),
-    '#description' => t('If displaying the parent and child title, what characters should delimit them? <em>(No quotes, html tags or special characters permitted.)</em>'),
+    '#description' => t('If displaying both the parent and child title, what characters should delimit them? <em>(No quotes, html tags or special characters permitted.)</em>'),
     '#default_value' => variable_get('islandora_social_metatags_compound_title_delimiter', ': '),
   );
   $form['islandora_social_metatags_compound_abstract'] = array(
@@ -96,8 +96,8 @@ function islandora_social_metatags_admin_form($form, $form_settings) {
   );
   $form['islandora_social_metatags_compound_abstract_delimiter'] = array(
     '#type' => 'textfield',
-    '#title' => t('Compound Object Title Concatenation Delimiter'),
-    '#description' => t('If displaying the parent and child abstract, what characters should delimit them? <em>(No quotes, html tags or special characters permitted.)</em>'),
+    '#title' => t('Compound Object Abstract Concatenation Delimiter'),
+    '#description' => t('If displaying both the parent and child abstract, what characters should delimit them? <em>(No quotes, html tags or special characters permitted.)</em>'),
     '#default_value' => variable_get('islandora_social_metatags_compound_abstract_delimiter', ' :: '),
   );
 

--- a/islandora_social_metatags.module
+++ b/islandora_social_metatags.module
@@ -21,15 +21,12 @@ function islandora_social_metatags_menu() {
   );
 }
 
-/**
+/*
 * Implements hook_islandora_view_object()
 */
 function islandora_social_metatags_islandora_view_object() {
  // first grab the MODS metadata and set all variables
   $object = menu_get_object('islandora_object', 2);
-  global $base_url;
-  $images = array();
-
   // Get Title.
   if (!isset($object['MODS'])) {
       return;
@@ -49,24 +46,6 @@ function islandora_social_metatags_islandora_view_object() {
     return;
   }
 
-  // If member of a compound object, prefix the object title with that of the parent.
-  $compound_parent = $object->relationships->get('info:fedora/fedora-system:def/relations-external#', 'isConstituentOf');
-  if(!empty($compound_parent && !empty($compound_parent[0]['object']['value']))) {
-    $compound_parent = islandora_object_load($compound_parent[0]['object']['value']);
-    if(!empty($compound_parent)) {
-      $doc = new DOMDocument();
-      $doc->loadXML($compound_parent['MODS']->content);
-      $xpath = new DOMXPath($doc);
-      $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
-      $xpath_results = $xpath->query(
-        variable_get('islandora_social_metatags_title_xpath', '/mods:mods/mods:titleInfo/mods:title')
-      );
-      if ($xpath_results->length > 0) {
-        $title = t('@parent: @child', array('@parent' => $xpath_results->item(0)->nodeValue, '@child' => $title));
-      }
-    }
-  }
-
   // Get Abstract
   $doc = new DOMDocument();
   $doc->loadXML($object['MODS']->content);
@@ -78,25 +57,7 @@ function islandora_social_metatags_islandora_view_object() {
 
   // If there is no Abstract field, use a default message.
   if ($xpath_results->length == 0) {
-    // Look to see if a parent exists, and if it has a description. If so, use it.
-    if (!empty($compound_parent)) {
-      $doc = new DOMDocument();
-      $doc->loadXML($compound_parent['MODS']->content);
-      $xpath = new DOMXPath($doc);
-      $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
-      $xpath_results = $xpath->query(
-        variable_get('islandora_social_metatags_abstract_xpath', '/mods:mods/mods:abstract')
-      );
-      if (strlen($xpath_results->item(0)->nodeValue) == 0) {
-        $abstract = variable_get('islandora_social_metatags_no_description', 'No description given.');
-      }
-      else {
-        $abstract = $xpath_results->item(0)->nodeValue;
-      }
-    }
-    else {
-      $abstract = variable_get('islandora_social_metatags_no_description', 'No description given.');
-    }
+    $abstract = variable_get('islandora_social_metatags_no_description', 'No description given.');
   }
   // In case of abstract field <abstract/>, use string length.
   elseif (strlen($xpath_results->item(0)->nodeValue) == 0) {
@@ -108,27 +69,44 @@ function islandora_social_metatags_islandora_view_object() {
 
   $pid = $object->id;
 
-  // Compound objects have multiple images.
-  if(in_array('islandora:compoundCModel', $object->models)) {
-    $parts = islandora_compound_object_get_parts($object->id);
-    foreach ($parts as $part) {
-      $child_object = islandora_object_load($part);
-      $child_image_datastream = _ism_get_image_datastream($child_object);
-      $images[] = $base_url . "/islandora/object/" . $child_object->id . "/datastream/" . $child_image_datastream . "/view";
-    }
+  // Get Image path. TO DO: Error handling if no image exists.
+  if (in_array('ir:citationCModel', $object->models)) {
+        $image_datastream = variable_get('islandora_social_metatags_citation_datastream', 'PREVIEW');
+  }
+  elseif (in_array('ir:thesisCModel', $object->models)) {
+    $image_datastream = variable_get('islandora_social_metatags_thesis_datastream', 'PREVIEW');
+  }
+  elseif (in_array('islandora:sp_large_image_cmodel', $object->models)) {
+   $image_datastream = variable_get('islandora_social_metatags_largeimage_datastream', 'JPG');
+  }
+  elseif (in_array('islandora:sp_basic_image', $object->models)) {
+   $image_datastream = variable_get('islandora_social_metatags_basicimage_datastream', 'MEDIUM_SIZE');
+  }
+  elseif (in_array('islandora:sp_videoCModel', $object->models)) {
+   $image_datastream = variable_get('islandora_social_metatags_video_datastream', 'TN');
   }
   else {
-    // Get Image path. TO DO: Error handling if no image exists.
-    $image_datastream = _ism_get_image_datastream($object);
-    $images[] = $base_url . "/islandora/object/" . $pid . "/datastream/" . $image_datastream . "/view";
+    $image_datastream = "TN";
   }
 
+  global $base_url;
+  $image = $base_url . "/islandora/object/" . $pid . "/datastream/" . $image_datastream . "/view";
   $og_url = $base_url . "/islandora/object/" . $pid;
+// Check whether the image datastream actually exists..
 
+  $file = $image;
+  $file_headers = @get_headers($file);
 
+  if (!$file_headers || strpos($file_headers[0], '404')) {
+    $exists = FALSE;
+  }
+  else {
+    $exists = TRUE;
+  }
+ 
 // If the datastream does not exist, use the default image path. 
-  if (empty($images)) {
-    $images[] = $base_url . variable_get('islandora_social_metatags_noimage', '/sites/all/modules/islandora/images/folder.png');
+  if (!$exists) {
+    $image = $base_url . variable_get('islandora_social_metatags_noimage', '/sites/all/modules/islandora/images/folder.png');
   }
 
   // Get Twitter user
@@ -141,7 +119,6 @@ function islandora_social_metatags_islandora_view_object() {
 * Implements drupal_add_html_head() to inject the meta tags
 */
 
-  // Twitter card
   $tags = array(
     'Twitter card' => array(
       '#tag' => 'meta',
@@ -156,7 +133,6 @@ function islandora_social_metatags_islandora_view_object() {
     drupal_add_html_head($val, $key);
   }
 
-  // Title tags
   $tags = array(
     'Twitter Title' => array(
       '#tag' => 'meta',
@@ -186,30 +162,36 @@ function islandora_social_metatags_islandora_view_object() {
     drupal_add_html_head($val, $key);
   }
 
-  // Image tags (maximum of six allowed).
-  foreach(array_slice($images, 0, 6) as $i => $image) {
-    $image_tags = array(
-      'Twitter image '. $i => array(
-        '#tag' => 'meta',
-        '#attributes' => array(
-          'name' => 'twitter:image',
-          'content' => $image
-        )
-      ),
-      'Facebook image ' . $i  => array(
-        '#tag' => 'meta',
-        '#attributes' => array(
-          'property' => 'og:image',
-          'content' => $image
-        )
+
+  $tags = array(
+    'Twitter image' => array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        'name' => 'twitter:image',
+        'content' => $image
       )
-    );
-    foreach ($image_tags as $key => $val) {
-      drupal_add_html_head($val, $key);
-    }
+    )
+  );
+
+  foreach ($tags as $key => $val) {
+    drupal_add_html_head($val, $key);
   }
 
-  // Twitter user.
+  $tags = array(
+    'Facebook image' => array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        'property' => 'og:image',
+        'content' => $image
+      )
+    )
+  );
+
+  foreach ($tags as $key => $val) {
+    drupal_add_html_head($val, $key);
+  }
+
+
   $tags = array(
     'Twitter site user' => array(
       '#tag' => 'meta',
@@ -224,7 +206,6 @@ function islandora_social_metatags_islandora_view_object() {
     drupal_add_html_head($val, $key);
   }
 
-  // Description.
   $tags = array(
     'Twitter description' => array(
       '#tag' => 'meta',
@@ -297,36 +278,4 @@ function islandora_social_metatags_islandora_view_object() {
     drupal_add_html_head($val, $key);
   }
 
-}
-
-
-/**
- * Get the preferred datastream to use for preview image.
- *
- * @param IslandoraFedoraObject $object
- * @return null|string
- *   If none found, return an empty string. Otherwise, return the DSID.
- */
-function _ism_get_image_datastream(IslandoraFedoraObject $object) {
-  // Get Image path. TO DO: Error handling if no image exists.
-  $image_datastream = '';
-  if (in_array('ir:citationCModel', $object->models)) {
-    $image_datastream = variable_get('islandora_social_metatags_citation_datastream', 'PREVIEW');
-  }
-  elseif (in_array('ir:thesisCModel', $object->models)) {
-    $image_datastream = variable_get('islandora_social_metatags_thesis_datastream', 'PREVIEW');
-  }
-  elseif (in_array('islandora:sp_large_image_cmodel', $object->models)) {
-    $image_datastream = variable_get('islandora_social_metatags_largeimage_datastream', 'JPG');
-  }
-  elseif (in_array('islandora:sp_basic_image', $object->models)) {
-    $image_datastream = variable_get('islandora_social_metatags_basicimage_datastream', 'MEDIUM_SIZE');
-  }
-  elseif (in_array('islandora:sp_videoCModel', $object->models)) {
-    $image_datastream = variable_get('islandora_social_metatags_video_datastream', 'TN');
-  }
-  if((empty($image_datastream) || empty($object[$image_datastream])) && !empty($object['TN'])) {
-    $image_datastream = "TN";
-  }
-  return $image_datastream;
 }

--- a/islandora_social_metatags.module
+++ b/islandora_social_metatags.module
@@ -21,243 +21,326 @@ function islandora_social_metatags_menu() {
   );
 }
 
-/*
-* Implements hook_islandora_view_object()
-*/
+/**
+ * Implements hook_islandora_view_object()
+ */
 function islandora_social_metatags_islandora_view_object() {
- // first grab the MODS metadata and set all variables
-  $object = menu_get_object('islandora_object', 2);
-  // Get Title.
-  if (!isset($object['MODS'])) {
+  // first grab the MODS metadata and set all variables
+
+  $has_run = &drupal_static(__FUNCTION__);
+  if (!isset($has_run)) {
+
+    $object = menu_get_object('islandora_object', 2);
+    // Get Title(s) -- if part of a compound object, concatenate the parent's title with that of the child.
+    if (!isset($object['MODS'])) {
       return;
-     }
-  $doc = new DOMDocument();
-  $doc->loadXML($object['MODS']->content);
-  $xpath = new DOMXPath($doc);
-  $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
-  $xpath_results = $xpath->query(
-    variable_get('islandora_social_metatags_title_xpath', '/mods:mods/mods:titleInfo/mods:title')
-  );
-  if ($xpath_results->length == 0) {
-    return;
-  }
-  $title = $xpath_results->item(0)->nodeValue;
-  if (!$title) {
-    return;
-  }
+    }
+    $titles = array();
+    // Get a title for this object
+    $doc = new DOMDocument();
+    $doc->loadXML($object['MODS']->content);
+    $xpath = new DOMXPath($doc);
+    $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
+    $xpath_results = $xpath->query(
+      variable_get('islandora_social_metatags_title_xpath', '/mods:mods/mods:titleInfo/mods:title')
+    );
+    if ($xpath_results->length > 0) {
+      $titles[] = $xpath_results->item(0)->nodeValue;
+    }
 
-  // Get Abstract
-  $doc = new DOMDocument();
-  $doc->loadXML($object['MODS']->content);
-  $xpath = new DOMXPath($doc);
-  $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
-  $xpath_results = $xpath->query(
-    variable_get('islandora_social_metatags_abstract_xpath', '/mods:mods/mods:abstract')
-  );
+    // If member of a compound object, prefix this object's title with that of the parent.
+    $compound_parent = $object->relationships->get('info:fedora/fedora-system:def/relations-external#', 'isConstituentOf');
+    if (!empty($compound_parent && !empty($compound_parent[0]['object']['value']))) {
+      $compound_parent = islandora_object_load($compound_parent[0]['object']['value']);
+      if (!empty($compound_parent)) {
+        $doc = new DOMDocument();
+        $doc->loadXML($compound_parent['MODS']->content);
+        $xpath = new DOMXPath($doc);
+        $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
+        $xpath_results = $xpath->query(
+          variable_get('islandora_social_metatags_title_xpath', '/mods:mods/mods:titleInfo/mods:title')
+        );
+        if ($xpath_results->length > 0) {
+          array_unshift($titles, $xpath_results->item(0)->nodeValue);
+        }
+      }
+    }
+    array_filter($titles);
 
-  // If there is no Abstract field, use a default message.
-  if ($xpath_results->length == 0) {
-    $abstract = variable_get('islandora_social_metatags_no_description', 'No description given.');
-  }
-  // In case of abstract field <abstract/>, use string length.
-  elseif (strlen($xpath_results->item(0)->nodeValue) == 0) {
-        $abstract = variable_get('islandora_social_metatags_no_description', 'No description given.');
-  }
-  else {
-    $abstract = $xpath_results->item(0)->nodeValue;
-  }
+    if (empty($titles)) {
+      return;
+    }
+    else {
+      $title = htmlspecialchars(implode(": ", $titles));
+    }
 
-  $pid = $object->id;
+    // Get Abstract
+    $abstract = _ism_object_abstract($object);
+    if (empty($abstract) && !empty($compound_parent)) {
+      // Attempt to get abstract from the parent.
+      $abstract = _ism_object_abstract($compound_parent);
+    }
+    // Provide default abstract if none found.
+    if (empty($abstract)) {
+      $abstract = variable_get('islandora_social_metatags_no_description', 'No description given.');
+    }
+    $abstract = htmlspecialchars($abstract);
 
-  // Get Image path and item type. Item type required for schema.org tags.
-  if (in_array('ir:citationCModel', $object->models) || in_array('ir:thesisCModel', $object->models)) {
-    $image_datastream = variable_get('islandora_social_metatags_citation_datastream', 'PREVIEW');
-    $itemtype = "Article";
-  }
-  elseif (in_array('islandora:sp_large_image_cmodel', $object->models)) {
-    $image_datastream = variable_get('islandora_social_metatags_largeimage_datastream', 'JPG');
-    $itemtype = "ImageObject";
-  }
-  elseif (in_array('islandora:sp_basic_image', $object->models)) {
-    $image_datastream = variable_get('islandora_social_metatags_basicimage_datastream', 'MEDIUM_SIZE');
-    $itemtype = "ImageObject";
-  }
-  elseif (in_array('islandora:sp_videoCModel', $object->models)) {
-    $image_datastream = variable_get('islandora_social_metatags_video_datastream', 'TN');
-    $itemtype = "VideoObject";
-  }
-  elseif (in_array('islandora:personCModel', $object->models)) {
-    $image_datastream = "TN";
-    $itemtype = "Person";
-  }
-  elseif (in_array('islandora:sp_pdf', $object->models) || in_array('islandora:sp_document', $object->models)) {
-    $image_datastream = "PREVIEW";
-    $itemtype = "DigitalDocument";
-  }
-  elseif (in_array('islandora:collectionCModel', $object->models)) {
-    $image_datastream = "TN";
-    $itemtype = "CollectionPage";
-  }
-  elseif (in_array('islandora:sp-audioCModel', $object->models)) {
-    $image_datastream = "TN";
-    $itemtype = "AudioObject";
-  }
-  elseif (in_array('islandora:bookCModel', $object->models) || in_array ('islandora:pageCModel', $object->models)) {
-    $image_datastream = "TN";
-    $itemtype = "Book";
-  }
-  elseif (in_array('islandora:newspaperCModel', $object->models) || in_array('islandora:newspaperIssueCModel', $object->models)) {
-    $image_datastream = "TN";
-    $itemtype = "NewsArticle";
-  }
-  elseif (in_array('islandora:newspaperPageCModel', $object->models)) {
-    $image_datastream = "JPG";
-    $itemtype = "NewsArticle";
-  }
-  elseif (in_array('islandora:eventCModel', $object->models)) {
-    $image_datastream = "TN";
-    $itemtype = "Event";
-  }
-  elseif (in_array('islandora:placeCModel', $object->models)) {
-    $image_datastream = "TN";
-    $itemtype = "Place";
-  }
-  elseif (in_array('islandora:organizationCModel', $object->models)) {
-    $image_datastream = "TN";
-    $itemtype = "Organization";
-  }
-  elseif (in_array('islandora:sp_disk_image', $object->models)) {
-    $image_datastream = "TN";
-    $itemtype = "DataCatalog";
-  }
-  elseif (in_array('islandora:sp_web_archive', $object->models)) {
-    $image_datastream = "JPG";
-    $itemtype = "WebSite";
-  }
-  else {
-    $image_datastream = "TN";
-    $itemtype = "Article";
-  }
+    // For the purpose of generating image tags, if this object is a compound, then
+    // switch to using the nearest first child that is not a compound object.
+    $object = _ism_get_image_object($object);
 
-  global $base_url;
-  $image = $base_url . "/islandora/object/" . $pid . "/datastream/" . $image_datastream . "/view";
-  $og_url = $base_url . "/islandora/object/" . $pid;
-// Check whether the image datastream actually exists..
+    $pid = $object->id;
 
-  $file = $image;
-  $file_headers = @get_headers($file);
+    // Get Image path and item type. Item type required for schema.org tags.
+    if (in_array('ir:citationCModel', $object->models) || in_array('ir:thesisCModel', $object->models)) {
+      $image_datastream = variable_get('islandora_social_metatags_citation_datastream', 'PREVIEW');
+      $itemtype = "Article";
+    }
+    elseif (in_array('islandora:sp_large_image_cmodel', $object->models)) {
+      $image_datastream = variable_get('islandora_social_metatags_largeimage_datastream', 'JPG');
+      $itemtype = "ImageObject";
+    }
+    elseif (in_array('islandora:sp_basic_image', $object->models)) {
+      $image_datastream = variable_get('islandora_social_metatags_basicimage_datastream', 'MEDIUM_SIZE');
+      $itemtype = "ImageObject";
+    }
+    elseif (in_array('islandora:sp_videoCModel', $object->models)) {
+      $image_datastream = variable_get('islandora_social_metatags_video_datastream', 'TN');
+      $itemtype = "VideoObject";
+    }
+    elseif (in_array('islandora:personCModel', $object->models)) {
+      $image_datastream = "TN";
+      $itemtype = "Person";
+    }
+    elseif (in_array('islandora:sp_pdf', $object->models) || in_array('islandora:sp_document', $object->models)) {
+      $image_datastream = "PREVIEW";
+      $itemtype = "DigitalDocument";
+    }
+    elseif (in_array('islandora:collectionCModel', $object->models)) {
+      $image_datastream = "TN";
+      $itemtype = "CollectionPage";
+    }
+    elseif (in_array('islandora:sp-audioCModel', $object->models)) {
+      $image_datastream = "TN";
+      $itemtype = "AudioObject";
+    }
+    elseif (in_array('islandora:bookCModel', $object->models) || in_array('islandora:pageCModel', $object->models)) {
+      $image_datastream = "TN";
+      $itemtype = "Book";
+    }
+    elseif (in_array('islandora:newspaperCModel', $object->models) || in_array('islandora:newspaperIssueCModel', $object->models)) {
+      $image_datastream = "TN";
+      $itemtype = "NewsArticle";
+    }
+    elseif (in_array('islandora:newspaperPageCModel', $object->models)) {
+      $image_datastream = "JPG";
+      $itemtype = "NewsArticle";
+    }
+    elseif (in_array('islandora:eventCModel', $object->models)) {
+      $image_datastream = "TN";
+      $itemtype = "Event";
+    }
+    elseif (in_array('islandora:placeCModel', $object->models)) {
+      $image_datastream = "TN";
+      $itemtype = "Place";
+    }
+    elseif (in_array('islandora:organizationCModel', $object->models)) {
+      $image_datastream = "TN";
+      $itemtype = "Organization";
+    }
+    elseif (in_array('islandora:sp_disk_image', $object->models)) {
+      $image_datastream = "TN";
+      $itemtype = "DataCatalog";
+    }
+    elseif (in_array('islandora:sp_web_archive', $object->models)) {
+      $image_datastream = "JPG";
+      $itemtype = "WebSite";
+    }
+    else {
+      $image_datastream = "TN";
+      $itemtype = "Article";
+    }
 
-  if (!$file_headers || strpos($file_headers[0], '404')) {
-    $exists = FALSE;
+    global $base_url;
+    $image = $base_url . "/islandora/object/" . $pid . "/datastream/" . $image_datastream . "/view";
+    $og_url = $base_url . "/islandora/object/" . $pid;
+    // Check whether the image datastream actually exists..
+
+    $file = $image;
+    $file_headers = @get_headers($file);
+
+    if (!$file_headers || strpos($file_headers[0], '404')) {
+      $exists = FALSE;
+    }
+    else {
+      $exists = TRUE;
+    }
+
+    // If the datastream does not exist, use the default image path.
+    if (!$exists) {
+      $image = $base_url . variable_get('islandora_social_metatags_noimage', '/sites/all/modules/islandora/images/folder.png');
+    }
+
+    // Get Twitter user
+    $twitter_user = variable_get('islandora_social_metatags_twitter_user');
+
+    // Turns out that Twitter no longer recognizes older card types, so this is the only option.
+    $card_type = "summary_large_image";
+
+    /*
+    * Implements drupal_add_html_head() to inject the meta tags
+    */
+    $site_name = variable_get('site_name', 'Islandora');
+    $tags = [
+      'Twitter card' => [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => 'twitter:card',
+          'content' => $card_type,
+        ],
+      ],
+      'Twitter Title' => [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => 'twitter:title',
+          'content' => $title,
+        ],
+      ],
+      'Facebook Title' => [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'property' => 'og:title',
+          'content' => $title,
+        ],
+      ],
+      'Twitter image' => [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => 'twitter:image',
+          'content' => $image,
+        ],
+      ],
+      'Facebook image' => [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'property' => 'og:image',
+          'content' => $image,
+        ],
+      ],
+      'Twitter site user' => [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => 'twitter:site',
+          'content' => $twitter_user,
+        ],
+      ],
+      'Twitter description' => [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => 'twitter:description',
+          'content' => $abstract,
+        ],
+      ],
+      'Facebook description' => [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'property' => 'og:description',
+          'content' => $abstract,
+        ],
+      ],
+      'Object type' => [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'property' => 'og:type',
+          'content' => 'article',
+        ],
+      ],
+      'Facebook URL' => [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'property' => 'og:url',
+          'content' => $og_url,
+        ],
+      ],
+      'Facebook site name' => [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'property' => 'og:site_name',
+          'content' => $site_name,
+        ],
+      ],
+    ];
+
+    foreach ($tags as $key => $val) {
+      drupal_add_html_head($val, $key);
+    }
+
+    // Add the schema.org meta tags separately, as they require their own div.
+    $itemscope = '<div itemscope itemtype = "http://schema.org/' . $itemtype . '">
+    <meta itemprop="name" content="' . htmlspecialchars($title) . '">
+    <meta itemprop="description" content="' . htmlspecialchars($abstract) . '">
+    <meta itemprop="image" content="' . $image . '">
+    </div>';
+
+    $script = '//--><!]]></script>' . $itemscope . '<script type="text/javascript"><!--//--><![CDATA[//><!--';
+    drupal_add_js($script, 'inline', 'footer');
+
+    $has_run = TRUE;
   }
-  else {
-    $exists = TRUE;
+}
+
+/**
+ * Attempt to get the abstract for an object.
+ *
+ * @param AbstractFedoraObject $object
+ *
+ * @return string
+ *   The abstract, or empty string if not found.
+ */
+function _ism_object_abstract(AbstractFedoraObject $object) {
+  $abstract = '';
+  if (!empty($object['MODS']->content)) {
+    $doc = new DOMDocument();
+    $doc->loadXML($object['MODS']->content);
+    $xpath = new DOMXPath($doc);
+    $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
+    $xpath_results = $xpath->query(
+      variable_get('islandora_social_metatags_abstract_xpath', '/mods:mods/mods:abstract')
+    );
+    if (!empty($xpath_results->item(0)->nodeValue) && strlen($xpath_results->item(0)->nodeValue) > 0) {
+      $abstract = $xpath_results->item(0)->nodeValue;
+    }
   }
- 
-// If the datastream does not exist, use the default image path. 
-  if (!$exists) {
-    $image = $base_url . variable_get('islandora_social_metatags_noimage', '/sites/all/modules/islandora/images/folder.png');
+  return $abstract;
+}
+
+/**
+ * Get a suitable object to use for the image tag.
+ *
+ * Handle possible case where the object is a compound object,
+ * and continue recursively if the first child is also a compound object.
+ *
+ * @param \AbstractFedoraObject $object
+ *
+ * @return \AbstractFedoraObject|\FedoraObject
+ */
+function _ism_get_image_object(AbstractFedoraObject $object) {
+  // For the purpose of generating image tags, if this object is a compound, then
+  // switch to using the first child of this object.
+  if (in_array('islandora:compoundCModel', $object->models)) {
+    $parts = islandora_compound_object_get_parts($object->id);
+    if (!empty($parts)) {
+      $first_part = reset($parts);
+      $part_object = islandora_object_load($first_part);
+      if (!empty($part_object)) {
+        $object = $part_object;
+        // Recurse if this child is a compound object.
+        if (in_array('islandora:compoundCModel', $object->models)) {
+          $object = _ism_get_image_object($object);
+        }
+      }
+    }
   }
-
-  // Get Twitter user
-  $twitter_user = variable_get('islandora_social_metatags_twitter_user');
-
-  // Turns out that Twitter no longer recognizes older card types, so this is the only option.
-  $card_type = "summary_large_image";
-
-/*
-* Implements drupal_add_html_head() to inject the meta tags
-*/
-  $site_name = variable_get('site_name', 'Islandora');
-  $tags = array(
-    'Twitter card' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'name' => 'twitter:card',
-        'content' => $card_type
-      )
-    ),
-    'Twitter Title' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'name' => 'twitter:title',
-        'content' => $title
-      )
-    ),
-    'Facebook Title' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'property' => 'og:title',
-        'content' => $title
-      )
-    ),
-    'Twitter image' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'name' => 'twitter:image',
-        'content' => $image
-      )
-    ),
-    'Facebook image' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'property' => 'og:image',
-        'content' => $image
-      )
-    ),
-    'Twitter site user' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'name' => 'twitter:site',
-        'content' => $twitter_user
-      )
-    ),
-    'Twitter description' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'name' => 'twitter:description',
-        'content' => $abstract 
-      )
-    ),
-    'Facebook description' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'property' => 'og:description',
-        'content' => $abstract
-      )
-    ),
-    'Object type' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'property' => 'og:type',
-        'content' => 'article'
-      )
-    ),
-    'Facebook URL' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'property' => 'og:url',
-        'content' => $og_url
-      )
-    ),
-    'Facebook site name' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'property' => 'og:site_name',
-        'content' => $site_name
-      )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-// Add the schema.org meta tags separately, as they require their own div.
-  print(
-    '<div itemscope itemtype = "http://schema.org/' . $itemtype . '">
-    <meta itemprop="name" content="' . $title . '">
-    <meta itemprop="description" content="' . $abstract . '">
-    <meta itemprop="image" content="' . $image . '"></div>'
-  );
+  return $object;
 }

--- a/islandora_social_metatags.module
+++ b/islandora_social_metatags.module
@@ -25,7 +25,6 @@ function islandora_social_metatags_menu() {
  * Implements hook_islandora_view_object()
  */
 function islandora_social_metatags_islandora_view_object() {
-  // first grab the MODS metadata and set all variables
 
   $has_run = &drupal_static(__FUNCTION__);
   if (!isset($has_run)) {
@@ -35,59 +34,90 @@ function islandora_social_metatags_islandora_view_object() {
     if (!isset($object['MODS'])) {
       return;
     }
-    $titles = array();
-    // Get a title for this object
-    $doc = new DOMDocument();
-    $doc->loadXML($object['MODS']->content);
-    $xpath = new DOMXPath($doc);
-    $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
-    $xpath_results = $xpath->query(
-      variable_get('islandora_social_metatags_title_xpath', '/mods:mods/mods:titleInfo/mods:title')
-    );
-    if ($xpath_results->length > 0) {
-      $titles[] = $xpath_results->item(0)->nodeValue;
-    }
 
-    // If member of a compound object, prefix this object's title with that of the parent.
+    //// Set up for compound object.
+    $objects = array('parent' => NULL, 'child' => NULL);
+    $titles = array();
     $compound_parent = $object->relationships->get('info:fedora/fedora-system:def/relations-external#', 'isConstituentOf');
     if (!empty($compound_parent && !empty($compound_parent[0]['object']['value']))) {
-      $compound_parent = islandora_object_load($compound_parent[0]['object']['value']);
-      if (!empty($compound_parent)) {
+      $objects['parent'] = islandora_object_load($compound_parent[0]['object']['value']);
+      $objects['child'] = $object;
+    }
+    elseif (in_array('islandora:compoundCModel', $object->models)) {
+      $children = islandora_compound_object_get_parts($object);
+      if(!empty($children[0])) {
+        $objects['parent'] = $object;
+        $objects['child'] = islandora_object_load($children[0]);
+      }
+    }
+    else {
+      // Not compound, handle normally.
+      $objects = array($object);
+    }
+
+    $abstract_objects = $title_objects = $objects;
+
+    //// Get Title.
+    // If none available, exit.
+    if(count($title_objects > 1)) {
+      $title_pref = variable_get('islandora_social_metatags_compound_title', 'concatenate');
+      // Remove parent or child as appropriate.
+      switch($title_pref) {
+        case 'parent':
+          unset($title_objects['child']);
+          break;
+        case 'child':
+          unset($title_objects['parent']);
+          break;
+      }
+    }
+    foreach ($title_objects as $key => $title_object) {
+      if(isset($object['MODS'])) {
         $doc = new DOMDocument();
-        $doc->loadXML($compound_parent['MODS']->content);
+        $doc->loadXML($title_object['MODS']->content);
         $xpath = new DOMXPath($doc);
         $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
         $xpath_results = $xpath->query(
           variable_get('islandora_social_metatags_title_xpath', '/mods:mods/mods:titleInfo/mods:title')
         );
         if ($xpath_results->length > 0) {
-          array_unshift($titles, $xpath_results->item(0)->nodeValue);
+          $titles[] = $xpath_results->item(0)->nodeValue;
         }
       }
     }
     array_filter($titles);
-
     if (empty($titles)) {
+      // No title, no metatags.
       return;
     }
     else {
-      $title = htmlspecialchars(implode(": ", $titles));
+      $title = implode(variable_get('islandora_social_metatags_compound_title_delimiter', ': '), $titles);
     }
 
-    // Get Abstract
-    $abstract = _ism_object_abstract($object);
-    if (empty($abstract) && !empty($compound_parent)) {
-      // Attempt to get abstract from the parent.
-      $abstract = _ism_object_abstract($compound_parent);
+    //// Get Abstract.
+    if (count($abstract_objects) > 1) {
+      $abstract_pref = variable_get('islandora_social_metatags_compound_abstract', 'concatenate');
+      // Remove parent or child if appropriate.
+      switch($abstract_pref) {
+        case 'parent':
+          unset($abstract_objects['child']);
+          break;
+        case 'child':
+          unset($abstract_objects['parent']);
+          break;
+      }
     }
+    $abstract = _ism_object_abstract($abstract_objects);
     // Provide default abstract if none found.
     if (empty($abstract)) {
       $abstract = variable_get('islandora_social_metatags_no_description', 'No description given.');
     }
-    $abstract = htmlspecialchars($abstract);
 
+    //// Get Image.
     // For the purpose of generating image tags, if this object is a compound, then
     // switch to using the nearest first child that is not a compound object.
+    // (This changes the $object variable, so must run after the title and abstract
+    // logic has run.)
     $object = _ism_get_image_object($object);
 
     $pid = $object->id;
@@ -276,6 +306,7 @@ function islandora_social_metatags_islandora_view_object() {
       drupal_add_html_head($val, $key);
     }
 
+    //// Add schema.org metadata.
     // Add the schema.org meta tags separately, as they require their own div.
     $itemscope = '<div itemscope itemtype = "http://schema.org/' . $itemtype . '">
     <meta itemprop="name" content="' . htmlspecialchars($title) . '">
@@ -286,6 +317,7 @@ function islandora_social_metatags_islandora_view_object() {
     $script = '//--><!]]></script>' . $itemscope . '<script type="text/javascript"><!--//--><![CDATA[//><!--';
     drupal_add_js($script, 'inline', 'footer');
 
+    // Don't do this again.
     $has_run = TRUE;
   }
 }
@@ -293,26 +325,31 @@ function islandora_social_metatags_islandora_view_object() {
 /**
  * Attempt to get the abstract for an object.
  *
- * @param AbstractFedoraObject $object
+ * Takes an array of objects. The first one with a usable abstract will be used.
+ * If none are usable, return empty string.
+ *
+ * @param array $objects
  *
  * @return string
  *   The abstract, or empty string if not found.
  */
-function _ism_object_abstract(AbstractFedoraObject $object) {
-  $abstract = '';
-  if (!empty($object['MODS']->content)) {
-    $doc = new DOMDocument();
-    $doc->loadXML($object['MODS']->content);
-    $xpath = new DOMXPath($doc);
-    $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
-    $xpath_results = $xpath->query(
-      variable_get('islandora_social_metatags_abstract_xpath', '/mods:mods/mods:abstract')
-    );
-    if (!empty($xpath_results->item(0)->nodeValue) && strlen($xpath_results->item(0)->nodeValue) > 0) {
-      $abstract = $xpath_results->item(0)->nodeValue;
+function _ism_object_abstract($objects) {
+  $abstracts = array();
+  foreach($objects as $object) {
+    if (!empty($object['MODS'])) {
+      $doc = new DOMDocument();
+      $doc->loadXML($object['MODS']->content);
+      $xpath = new DOMXPath($doc);
+      $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
+      $xpath_results = $xpath->query(
+        variable_get('islandora_social_metatags_abstract_xpath', '/mods:mods/mods:abstract')
+      );
+      if (!empty($xpath_results->item(0)->nodeValue) && strlen($xpath_results->item(0)->nodeValue) > 0) {
+        $abstracts[] = $xpath_results->item(0)->nodeValue;
+      }
     }
   }
-  return $abstract;
+  return implode(" :: ", $abstracts);
 }
 
 /**

--- a/islandora_social_metatags.module
+++ b/islandora_social_metatags.module
@@ -21,12 +21,15 @@ function islandora_social_metatags_menu() {
   );
 }
 
-/*
+/**
 * Implements hook_islandora_view_object()
 */
 function islandora_social_metatags_islandora_view_object() {
  // first grab the MODS metadata and set all variables
   $object = menu_get_object('islandora_object', 2);
+  global $base_url;
+  $images = array();
+
   // Get Title.
   if (!isset($object['MODS'])) {
       return;
@@ -46,6 +49,24 @@ function islandora_social_metatags_islandora_view_object() {
     return;
   }
 
+  // If member of a compound object, prefix the object title with that of the parent.
+  $compound_parent = $object->relationships->get('info:fedora/fedora-system:def/relations-external#', 'isConstituentOf');
+  if(!empty($compound_parent && !empty($compound_parent[0]['object']['value']))) {
+    $compound_parent = islandora_object_load($compound_parent[0]['object']['value']);
+    if(!empty($compound_parent)) {
+      $doc = new DOMDocument();
+      $doc->loadXML($compound_parent['MODS']->content);
+      $xpath = new DOMXPath($doc);
+      $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
+      $xpath_results = $xpath->query(
+        variable_get('islandora_social_metatags_title_xpath', '/mods:mods/mods:titleInfo/mods:title')
+      );
+      if ($xpath_results->length > 0) {
+        $title = t('@parent: @child', array('@parent' => $xpath_results->item(0)->nodeValue, '@child' => $title));
+      }
+    }
+  }
+
   // Get Abstract
   $doc = new DOMDocument();
   $doc->loadXML($object['MODS']->content);
@@ -57,7 +78,25 @@ function islandora_social_metatags_islandora_view_object() {
 
   // If there is no Abstract field, use a default message.
   if ($xpath_results->length == 0) {
-    $abstract = variable_get('islandora_social_metatags_no_description', 'No description given.');
+    // Look to see if a parent exists, and if it has a description. If so, use it.
+    if (!empty($compound_parent)) {
+      $doc = new DOMDocument();
+      $doc->loadXML($compound_parent['MODS']->content);
+      $xpath = new DOMXPath($doc);
+      $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
+      $xpath_results = $xpath->query(
+        variable_get('islandora_social_metatags_abstract_xpath', '/mods:mods/mods:abstract')
+      );
+      if (strlen($xpath_results->item(0)->nodeValue) == 0) {
+        $abstract = variable_get('islandora_social_metatags_no_description', 'No description given.');
+      }
+      else {
+        $abstract = $xpath_results->item(0)->nodeValue;
+      }
+    }
+    else {
+      $abstract = variable_get('islandora_social_metatags_no_description', 'No description given.');
+    }
   }
   // In case of abstract field <abstract/>, use string length.
   elseif (strlen($xpath_results->item(0)->nodeValue) == 0) {
@@ -69,44 +108,27 @@ function islandora_social_metatags_islandora_view_object() {
 
   $pid = $object->id;
 
-  // Get Image path. TO DO: Error handling if no image exists.
-  if (in_array('ir:citationCModel', $object->models)) {
-        $image_datastream = variable_get('islandora_social_metatags_citation_datastream', 'PREVIEW');
-  }
-  elseif (in_array('ir:thesisCModel', $object->models)) {
-    $image_datastream = variable_get('islandora_social_metatags_thesis_datastream', 'PREVIEW');
-  }
-  elseif (in_array('islandora:sp_large_image_cmodel', $object->models)) {
-   $image_datastream = variable_get('islandora_social_metatags_largeimage_datastream', 'JPG');
-  }
-  elseif (in_array('islandora:sp_basic_image', $object->models)) {
-   $image_datastream = variable_get('islandora_social_metatags_basicimage_datastream', 'MEDIUM_SIZE');
-  }
-  elseif (in_array('islandora:sp_videoCModel', $object->models)) {
-   $image_datastream = variable_get('islandora_social_metatags_video_datastream', 'TN');
+  // Compound objects have multiple images.
+  if(in_array('islandora:compoundCModel', $object->models)) {
+    $parts = islandora_compound_object_get_parts($object->id);
+    foreach ($parts as $part) {
+      $child_object = islandora_object_load($part);
+      $child_image_datastream = _ism_get_image_datastream($child_object);
+      $images[] = $base_url . "/islandora/object/" . $child_object->id . "/datastream/" . $child_image_datastream . "/view";
+    }
   }
   else {
-    $image_datastream = "TN";
+    // Get Image path. TO DO: Error handling if no image exists.
+    $image_datastream = _ism_get_image_datastream($object);
+    $images[] = $base_url . "/islandora/object/" . $pid . "/datastream/" . $image_datastream . "/view";
   }
 
-  global $base_url;
-  $image = $base_url . "/islandora/object/" . $pid . "/datastream/" . $image_datastream . "/view";
   $og_url = $base_url . "/islandora/object/" . $pid;
-// Check whether the image datastream actually exists..
 
-  $file = $image;
-  $file_headers = @get_headers($file);
 
-  if (!$file_headers || strpos($file_headers[0], '404')) {
-    $exists = FALSE;
-  }
-  else {
-    $exists = TRUE;
-  }
- 
 // If the datastream does not exist, use the default image path. 
-  if (!$exists) {
-    $image = $base_url . variable_get('islandora_social_metatags_noimage', '/sites/all/modules/islandora/images/folder.png');
+  if (empty($images)) {
+    $images[] = $base_url . variable_get('islandora_social_metatags_noimage', '/sites/all/modules/islandora/images/folder.png');
   }
 
   // Get Twitter user
@@ -119,6 +141,7 @@ function islandora_social_metatags_islandora_view_object() {
 * Implements drupal_add_html_head() to inject the meta tags
 */
 
+  // Twitter card
   $tags = array(
     'Twitter card' => array(
       '#tag' => 'meta',
@@ -133,6 +156,7 @@ function islandora_social_metatags_islandora_view_object() {
     drupal_add_html_head($val, $key);
   }
 
+  // Title tags
   $tags = array(
     'Twitter Title' => array(
       '#tag' => 'meta',
@@ -162,36 +186,30 @@ function islandora_social_metatags_islandora_view_object() {
     drupal_add_html_head($val, $key);
   }
 
-
-  $tags = array(
-    'Twitter image' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'name' => 'twitter:image',
-        'content' => $image
+  // Image tags (maximum of six allowed).
+  foreach(array_slice($images, 0, 6) as $i => $image) {
+    $image_tags = array(
+      'Twitter image '. $i => array(
+        '#tag' => 'meta',
+        '#attributes' => array(
+          'name' => 'twitter:image',
+          'content' => $image
+        )
+      ),
+      'Facebook image ' . $i  => array(
+        '#tag' => 'meta',
+        '#attributes' => array(
+          'property' => 'og:image',
+          'content' => $image
+        )
       )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
+    );
+    foreach ($image_tags as $key => $val) {
+      drupal_add_html_head($val, $key);
+    }
   }
 
-  $tags = array(
-    'Facebook image' => array(
-      '#tag' => 'meta',
-      '#attributes' => array(
-        'property' => 'og:image',
-        'content' => $image
-      )
-    )
-  );
-
-  foreach ($tags as $key => $val) {
-    drupal_add_html_head($val, $key);
-  }
-
-
+  // Twitter user.
   $tags = array(
     'Twitter site user' => array(
       '#tag' => 'meta',
@@ -206,6 +224,7 @@ function islandora_social_metatags_islandora_view_object() {
     drupal_add_html_head($val, $key);
   }
 
+  // Description.
   $tags = array(
     'Twitter description' => array(
       '#tag' => 'meta',
@@ -278,4 +297,36 @@ function islandora_social_metatags_islandora_view_object() {
     drupal_add_html_head($val, $key);
   }
 
+}
+
+
+/**
+ * Get the preferred datastream to use for preview image.
+ *
+ * @param IslandoraFedoraObject $object
+ * @return null|string
+ *   If none found, return an empty string. Otherwise, return the DSID.
+ */
+function _ism_get_image_datastream(IslandoraFedoraObject $object) {
+  // Get Image path. TO DO: Error handling if no image exists.
+  $image_datastream = '';
+  if (in_array('ir:citationCModel', $object->models)) {
+    $image_datastream = variable_get('islandora_social_metatags_citation_datastream', 'PREVIEW');
+  }
+  elseif (in_array('ir:thesisCModel', $object->models)) {
+    $image_datastream = variable_get('islandora_social_metatags_thesis_datastream', 'PREVIEW');
+  }
+  elseif (in_array('islandora:sp_large_image_cmodel', $object->models)) {
+    $image_datastream = variable_get('islandora_social_metatags_largeimage_datastream', 'JPG');
+  }
+  elseif (in_array('islandora:sp_basic_image', $object->models)) {
+    $image_datastream = variable_get('islandora_social_metatags_basicimage_datastream', 'MEDIUM_SIZE');
+  }
+  elseif (in_array('islandora:sp_videoCModel', $object->models)) {
+    $image_datastream = variable_get('islandora_social_metatags_video_datastream', 'TN');
+  }
+  if((empty($image_datastream) || empty($object[$image_datastream])) && !empty($object['TN'])) {
+    $image_datastream = "TN";
+  }
+  return $image_datastream;
 }


### PR DESCRIPTION
JIRA Ticket: none

# Why:
* When viewing a compound object, the metadata and image for the pid currently being displayed usually do not make sense.
* This function can be called more than once if there are multiple objects being displayed on the page.
* schema.org itemscope div breaks element heights in bootstrap

# What does this Pull Request do?
* When viewing a compound object, the title is derived by concatenating the parent object title with the title of the current child object.
* When viewing a compound object, try to display the abstract for the currently displayed child object. If empty, then try to display the abstract of the parent.
* When viewing a compound object, use the image of the child being displayed.
* To prevent running multiple times, use a static variable to keep track whether it has run previously. If so, do nothing.
* Inject the schema.org itemscope div using ajax.

# How should this be tested?
* A handy open graph preview plugin is linked below.
* View a compound object. Do the metatags make sense for the object currently being displayed? 
* View another child of the compound object. Do the metatags make sense for this child?
* Regression: View other kinds of objects, do the metatags make sense for those objects?

# Reference Links:
* [A handy Chrome plugin for previewing](https://chrome.google.com/webstore/detail/open-graph-preview/ehaigphokkgebnmdiicabhjhddkaekgh?hl=en)
* https://github.com/Islandora-Labs/islandora_social_metatags
* https://github.com/Islandora-Labs/islandora_social_metatags/pull/8


Interested parties
@bondjimbond 