### PR TITLE
Add norobots tags

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -100,6 +100,11 @@ function islandora_social_metatags_admin_form($form, $form_settings) {
     '#description' => t('If displaying both the parent and child abstract, what characters should delimit them? <em>(No quotes, html tags or special characters permitted.)</em>'),
     '#default_value' => variable_get('islandora_social_metatags_compound_abstract_delimiter', ' :: '),
   );
-
+  $form['islandora_social_metatags_norobots'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Disable search engine indexing'),
+    '#description' => t('Inserts a noindex tag to turn away web crawlers.'),
+    '#default_value' => variable_get('islandora_social_metatags_norobots', FALSE),
+  );
   return system_settings_form($form);
 }

--- a/islandora_social_metatags.install
+++ b/islandora_social_metatags.install
@@ -18,7 +18,8 @@ function islandora_social_metatags_uninstall() {
     'islandora_social_metatags_video_datastream',
     'islandora_social_metatags_citation_datastream',
     'islandora_social_metatags_thesis_datastream',
-    'islandora_social_metatags_noimage'
+    'islandora_social_metatags_noimage',
+    'islandora_social_metatags_norobots'
   );
   array_walk($vars, 'variable_del');
 }

--- a/islandora_social_metatags.module
+++ b/islandora_social_metatags.module
@@ -53,7 +53,7 @@ function islandora_social_metatags_islandora_view_object() {
     else {
       // Not compound, handle normally.
       $objects = array($object);
-    }
+    }  
 
     $abstract_objects = $title_objects = $objects;
 
@@ -222,6 +222,9 @@ function islandora_social_metatags_islandora_view_object() {
     * Implements drupal_add_html_head() to inject the meta tags
     */
     $site_name = variable_get('site_name', 'Islandora');
+
+    // Get norobots rules.
+    $norobots = variable_get('islandora_social_metatags_norobots', FALSE);
     $tags = [
       'Twitter card' => [
         '#tag' => 'meta',
@@ -301,6 +304,16 @@ function islandora_social_metatags_islandora_view_object() {
         ],
       ],
     ];
+
+    if ($norobots == 1) {
+     $tags['robots'] = [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => 'robots',
+          'content' => "noindex, nofollow",
+          ],
+      ];
+    }
 
     foreach ($tags as $key => $val) {
       drupal_add_html_head($val, $key);


### PR DESCRIPTION
Addresses #13 

If you don't want your Islandora objects indexed by Google, you'll need a norobots meta tag. This feature provides such a tag.

To test:

- Check out this branch
- In the Config page, check the "Disable search engine indexing" option
- View an object's HTML source and verify that the tag `<meta name="robots" content="noindex, nofollow" />` appears.
- Un-check the option, view another object's HTML source, verify that the tag is not present.